### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -33,7 +33,7 @@ class syntax_plugin_dig extends DokuWiki_Syntax_Plugin {
         $this->Lexer->addSpecialPattern('<dig>\n.*?\n</dig>',$mode,'plugin_dig');
     }
 
-    function handle($match, $state, $pos, &$handler){
+    function handle($match, $state, $pos, Doku_Handler $handler){
 
         $lines = explode("\n",$match);
         array_shift($lines); // skip opening tag
@@ -43,7 +43,7 @@ class syntax_plugin_dig extends DokuWiki_Syntax_Plugin {
         return $data;
     }
 
-    function render($mode, &$R, $data) {
+    function render($mode, Doku_Renderer $R, $data) {
         if($mode != 'xhtml') return false;
 
         $R->doc .= '<table class="inline">';


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
